### PR TITLE
update @typescript-eslint/parser version from canary to latest versio…

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/umijs/umi-fabric#readme",
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^1.4.2",
-    "@typescript-eslint/parser": "canary",
+    "@typescript-eslint/parser": "^2.7.0",
     "eslint": "^6.5.1",
     "eslint-config-airbnb": "^17.1.0",
     "eslint-config-airbnb-base": "^13.1.0",


### PR DESCRIPTION
this problem happened in @typescript-eslint/parser@1.10.2 or that lower than
![image](https://user-images.githubusercontent.com/32446924/68639198-c5087b00-053e-11ea-8365-3dfd212ad53c.png)

according to https://github.com/typescript-eslint/typescript-eslint/issues/641#issuecomment-504795401
now need to update the version to **^2.7.0**.
