### PR TITLE
chore: update dependency typescript to 4.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "stylelint-config-standard": "^20.0.0",
     "stylelint-declaration-block-no-ignored-properties": "^2.1.0",
     "stylelint-order": "^4.0.0",
-    "typescript": "^4.0.0"
+    "typescript": "^4.0.2"
   },
   "devDependencies": {
     "np": "^6.2.5"


### PR DESCRIPTION
npm 上 typescript4 稳定版最低版本是 4.0.2，没有 4.0.0 这个版本，使用 yarn 安装依赖了 @umijs/fabric 的 package 时，会报 Couldn't find package "typescript@^4.0.0" required by "@umijs/fabric@^2.2.2" on the "npm" registry 错误