### PR TITLE
refactor: process.env.PWD ==> process.cwd()

### DIFF
--- a/src/eslint.ts
+++ b/src/eslint.ts
@@ -10,7 +10,7 @@ const parserOptions: {
   project: './tsconfig.json',
 };
 
-const isTsProject = fs.existsSync(path.join(process.env.PWD || '.', './tsconfig.json'));
+const isTsProject = fs.existsSync(path.join(process.cwd() || '.', './tsconfig.json'));
 
 if (isTsProject) {
   console.log('这是一个 TypeScript 项目，如果不是请删除 tsconfig.json');


### PR DESCRIPTION
`process.env.PWD` 依赖于运行系统的 [shell 设置](https://man7.org/linux/man-pages/man7/environ.7.html)，用在这里并不是很稳妥

从我现在的项目打印出来：
```
'/'             ---> process.env.PWD       
'/Users/atzcl/react/demo' ---> process.cwd()
```
[eslint 的默认设置就是使用 `process.cwd()`](https://eslint.org/docs/developer-guide/nodejs-api#%E2%97%86-new-eslint-options)