### PR TITLE
fix: Lock @typescript-eslint/eslint-plugin@5.8.1 to avoid breaking change by node engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@babel/preset-env": "^7.12.11",
     "@babel/preset-react": "^7.12.10",
     "@babel/preset-typescript": "^7.12.7",
-    "@typescript-eslint/eslint-plugin": "^5.8.1",
+    "@typescript-eslint/eslint-plugin": "5.8.1",
     "@typescript-eslint/parser": "^5.9.0",
     "chalk": "^4.1.1",
     "eslint": "^7.11.0",


### PR DESCRIPTION
close #120 