### PR TITLE
feat(disable-type-aware): Using env var to let user disable type-aware linting

### DIFF
--- a/src/eslint.ts
+++ b/src/eslint.ts
@@ -2,6 +2,8 @@ import * as path from 'path';
 import * as fs from 'fs';
 import tsEslintConfig from './tsEslintConfig';
 
+const isTypeAwareEnabled = process.env.DISABLE_TYPE_AWARE === undefined;
+
 const parserOptions = {
   ecmaFeatures: {
     jsx: true,
@@ -14,7 +16,7 @@ const parserOptions = {
     ],
   },
   requireConfigFile: false,
-  project: './tsconfig.json',
+  project: isTypeAwareEnabled ? './tsconfig.json' : undefined,
 };
 
 const isJsMoreTs = async (path = 'src') => {

--- a/src/tsEslintConfig.ts
+++ b/src/tsEslintConfig.ts
@@ -1,3 +1,5 @@
+const isTypeAwareEnabled = process.env.DISABLE_TYPE_AWARE === undefined;
+
 export default {
   'no-undef': 0,
   '@typescript-eslint/adjacent-overload-signatures': 0,
@@ -19,7 +21,7 @@ export default {
   'default-param-last': 'off',
   '@typescript-eslint/default-param-last': 0,
   'dot-notation': 'off',
-  '@typescript-eslint/dot-notation': 1,
+  '@typescript-eslint/dot-notation': isTypeAwareEnabled ? 1 : 0,
   '@typescript-eslint/explicit-function-return-type': 0,
   'func-call-spacing': 'off',
   '@typescript-eslint/func-call-spacing': 0,
@@ -79,7 +81,7 @@ export default {
   '@typescript-eslint/no-shadow': 'error',
   '@typescript-eslint/no-this-alias': 'error',
   'no-throw-literal': 'off',
-  '@typescript-eslint/no-throw-literal': 'error',
+  '@typescript-eslint/no-throw-literal': isTypeAwareEnabled ? 2 : 0,
   '@typescript-eslint/no-type-alias': 0,
   '@typescript-eslint/no-unnecessary-boolean-literal-compare': 0,
   '@typescript-eslint/no-unnecessary-condition': 0,
@@ -130,7 +132,7 @@ export default {
   'space-infix-ops': 'off',
   '@typescript-eslint/space-infix-ops': 0,
   '@typescript-eslint/strict-boolean-expressions': 0,
-  '@typescript-eslint/switch-exhaustiveness-check': 'error',
+  '@typescript-eslint/switch-exhaustiveness-check': isTypeAwareEnabled ? 2 : 0,
   '@typescript-eslint/triple-slash-reference': 'error',
   '@typescript-eslint/type-annotation-spacing': 'error',
   '@typescript-eslint/typedef': 'error',


### PR DESCRIPTION
# 背景

在 ESLint 搭配 Typescript 使用的场景中，若设置了 `parserOptions.project` 则称作 type-aware linting，即在 lint 时会同时考虑所有变量的类型定义，带来更强大的自定义规则。

但 type-aware linting 有一个众所周知的历史问题，同时也是 Typescript ESLint 官方自己都承认的问题 - 效率太差了。在开启 type-aware linting 的情况下，相当于 eslint 必须先将整个 ts 项目的类型定义编译过一次，才能够支持那些依赖类型定义的规则。

https://typescript-eslint.io/docs/linting/type-linting/#how-is-performance
https://github.com/typescript-eslint/typescript-eslint/issues/319
https://github.com/typescript-eslint/typescript-eslint/issues/243
https://github.com/typescript-eslint/typescript-eslint/issues/389

一般使用上可能问题不会很明显，但对于大型项目来说，从头启动 ESLint 可能要等数分钟甚至数小时才能完成检查。

# 解决方案

提供一个环境变量的配置方式，使用 umijs/fabric 规则的用户可以自行决定是否要开启 type-aware linting。

```bash
# type-aware
eslint src/**/*.tsx --fix 

# disabled type-aware
DISABLE_TYPE_AWARE=true src/**/*.tsx --fix 
```