### PR TITLE
docs: show more info when verify commit fails

### DIFF
--- a/src/verifyCommit.ts
+++ b/src/verifyCommit.ts
@@ -17,7 +17,7 @@ if (!commitRE.test(msg)) {
         `  ${chalk.bgRed.white(' ERROR ')} ${chalk.red(`提交日志不符合规范`)}\n\n${chalk.red(
           `  合法的提交日志格式如下(emoji 和 模块可选填)：\n\n`,
         )}    
-        ${chalk.green(`[<emoji>] <type>[<scope>]: <message>\n`)}
+        ${chalk.green(`[<emoji>] [revert: ?]<type>[(scope)?]: <message>\n`)}
         ${chalk.green(`💥 feat(模块): 添加了个很棒的功能`)}
         ${chalk.green(`🐛 fix(模块): 修复了一些 bug`)}
         ${chalk.green(`📝 docs(模块): 更新了一下文档`)}
@@ -34,7 +34,7 @@ if (!commitRE.test(msg)) {
         )}\n\n${chalk.red(
           `  Proper commit message format is required for automated changelog generation. Examples:\n\n`,
         )}    
-        ${chalk.green(`[<emoji>] <type>[<scope>]: <message>\n`)}
+        ${chalk.green(`[<emoji>] [revert: ?]<type>[(scope)?]: <message>\n`)}
         ${chalk.green(`💥 feat(compiler): add 'comments' option`)}
         ${chalk.green(`🐛 fix(compiler): fix some bug`)}
         ${chalk.green(`📝 docs(compiler): add some docs`)}

--- a/src/verifyCommit.ts
+++ b/src/verifyCommit.ts
@@ -17,13 +17,15 @@ if (!commitRE.test(msg)) {
         `  ${chalk.bgRed.white(' ERROR ')} ${chalk.red(`提交日志不符合规范`)}\n\n${chalk.red(
           `  合法的提交日志格式如下(emoji 和 模块可选填)：\n\n`,
         )}    
-    ${chalk.green(`💥 feat(模块): 添加了个很棒的功能`)}
-    ${chalk.green(`🐛 fix(模块): 修复了一些 bug`)}
-    ${chalk.green(`📝 docs(模块): 更新了一下文档`)}
-    ${chalk.green(`🌷 UI(模块): 修改了一下样式`)}
-    ${chalk.green(`🏰 chore(模块): 对脚手架做了些更改`)}
-    ${chalk.green(`🌐 locale(模块): 为国际化做了微小的贡献`)}
-    ${chalk.red(`See .github/commit-convention.md for more details.\n`)}`,
+        ${chalk.green(`[<emoji>] <type>[<scope>]: <message>\n`)}
+        ${chalk.green(`💥 feat(模块): 添加了个很棒的功能`)}
+        ${chalk.green(`🐛 fix(模块): 修复了一些 bug`)}
+        ${chalk.green(`📝 docs(模块): 更新了一下文档`)}
+        ${chalk.green(`🌷 UI(模块): 修改了一下样式`)}
+        ${chalk.green(`🏰 chore(模块): 对脚手架做了些更改`)}
+        ${chalk.green(`🌐 locale(模块): 为国际化做了微小的贡献\n`)}
+        ${chalk.green(`其他提交类型: refactor, ⚡perf, workflow, build, CI, typos, tests, types, wip, release, dep\n`)}
+        ${chalk.red(`See .github/commit-convention.md for more details.\n`)}`,
       );
     } else {
       console.error(
@@ -32,13 +34,15 @@ if (!commitRE.test(msg)) {
         )}\n\n${chalk.red(
           `  Proper commit message format is required for automated changelog generation. Examples:\n\n`,
         )}    
-    ${chalk.green(`💥 feat(compiler): add 'comments' option`)}
-    ${chalk.green(`🐛 fix(compiler): fix some bug`)}
-    ${chalk.green(`📝 docs(compiler): add some docs`)}
-    ${chalk.green(`🌷 UI(compiler): better styles`)}
-    ${chalk.green(`🏰 chore(compiler): Made some changes to the scaffolding`)}
-    ${chalk.green(`🌐 locale(compiler): Made a small contribution to internationalization`)}\n
-    ${chalk.red(`See .github/commit-convention.md for more details.\n`)}`,
+        ${chalk.green(`[<emoji>] <type>[<scope>]: <message>\n`)}
+        ${chalk.green(`💥 feat(compiler): add 'comments' option`)}
+        ${chalk.green(`🐛 fix(compiler): fix some bug`)}
+        ${chalk.green(`📝 docs(compiler): add some docs`)}
+        ${chalk.green(`🌷 UI(compiler): better styles`)}
+        ${chalk.green(`🏰 chore(compiler): Made some changes to the scaffolding`)}
+        ${chalk.green(`🌐 locale(compiler): Made a small contribution to internationalization\n`)}
+        ${chalk.green(`Other commit types: refactor, ⚡perf, workflow, build, CI, typos, tests, types, wip, release, dep\n`)}
+        ${chalk.red(`See .github/commit-convention.md for more details.\n`)}`,
       );
     }
 


### PR DESCRIPTION
### 背景

第一次使用 `ant-design-pro` 搭建项目，提交 commit 的时候提交失败

- `git commit -m "delete: i18n-删除所有语言资源文件，仅保留中英文"`

```
 > running pre-commit hook: npm run precommit

> ant-design-pro@5.2.0 precommit
> lint-staged

ℹ No staged files found.
 > running commit-msg hook: fabric verify-commit

   ERROR  提交日志不符合规范

  合法的提交日志格式如下(emoji 和 模块可选填)：

    
        💥 feat(模块): 添加了个很棒的功能
        🐛 fix(模块): 修复了一些 bug
        📝 docs(模块): 更新了一下文档
        🌷 UI(模块): 修改了一下样式
        🏰 chore(模块): 对脚手架做了些更改
        🌐 locale(模块): 为国际化做了微小的贡献
        See .github/commit-convention.md for more details.


commit-msg hook failed (add --no-verify to bypass)
```

```json
"gitHooks": {
    "commit-msg": "fabric verify-commit"
}
```

发现项目默认会校验 commit message，但是从现有的提示中没有找到合适的 commit type（感觉这种情况，隔绝了很多想用校验，但是因为不了解相关规范，没法舒适使用，于是弃用的潜在用户），我其实也想干脆直接去掉校验算了，但是想想还是查了查，于是找到了这个仓库，以及对应负责校验的 `verifyCommit.ts`。

通过阅读正则表达式，发现满足我的条件并且能通过校验的 commit message 得这样写：

- `git commit -m "delete: i18n-删除所有语言资源文件，仅保留中英文"`
- `git commit -m "revert: locale: i18n-删除所有语言资源文件，仅保留中英文"`

### 改动

为了方便用户快捷的找到合适的 commit type，写出通过校验的 commit message，做了如下改动：

- 校验不通过时，显示更多提示信息（基本校验规则、其余 commit 类型）并微调排版
  - `[<emoji>] <type>[<scope>]: <message>`
- 校验不通过时，显示详细的校验规则（增加 `revert` 相关的内容）
  - `[<emoji>] [revert: ?]<type>[(scope)?]: <message>`

#### 测试/预览改动

```diff
"devDependencies": {
-  "@umijs/fabric": "^2.8.0",
+  "@umijs/fabric": "/Users/lsnsh/***/fork/fabric"
}
```

将改动运行测试脚本后，在自己项目中，改用绝对路径重新安装 `@umijs/fabric`，测试提交 commit 后，实际效果如下：

**中文：**

```log
➜  *** git:(master) ✗ git commit -m "delete: i18n-删除所有语言资源文件，仅保留中英文"
 > running pre-commit hook: npm run precommit

> ant-design-pro@5.2.0 precommit
> lint-staged

ℹ No staged files found.
 > running commit-msg hook: fabric verify-commit

   ERROR  提交日志不符合规范

  合法的提交日志格式如下(emoji 和 模块可选填)：

    
        [<emoji>] [revert: ?]<type>[(scope)?]: <message>

        💥 feat(模块): 添加了个很棒的功能
        🐛 fix(模块): 修复了一些 bug
        📝 docs(模块): 更新了一下文档
        🌷 UI(模块): 修改了一下样式
        🏰 chore(模块): 对脚手架做了些更改
        🌐 locale(模块): 为国际化做了微小的贡献

        其他提交类型: refactor, ⚡perf, workflow, build, CI, typos, tests, types, wip, release, dep

        See .github/commit-convention.md for more details.


commit-msg hook failed (add --no-verify to bypass)
```

**英文：**

```log
> git -c user.useConfigOnly=true commit --quiet --allow-empty-message --file -
 > running pre-commit hook: npm run precommit

> ant-design-pro@5.2.0 precommit
> lint-staged

ℹ No staged files found.
 > running commit-msg hook: fabric verify-commit

   ERROR  invalid commit message format.

  Proper commit message format is required for automated changelog generation. Examples:

    
        [<emoji>] [revert: ?]<type>[(scope)?]: <message>

        💥 feat(compiler): add 'comments' option
        🐛 fix(compiler): fix some bug
        📝 docs(compiler): add some docs
        🌷 UI(compiler): better styles
        🏰 chore(compiler): Made some changes to the scaffolding
        🌐 locale(compiler): Made a small contribution to internationalization

        Other commit types: refactor, ⚡perf, workflow, build, CI, typos, tests, types, wip, release, dep

        See .github/commit-convention.md for more details.


commit-msg hook failed (add --no-verify to bypass)
```

### 参考资料

- [gitmoji][0]
- [Angular Git Commit Message Conventions][1]
- [AngularJS Git Commit Message Conventions][2]

[0]: https://github.com/carloscuesta/gitmoji
[1]: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#type
[2]: https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit?usp=sharing