### PR TITLE
Fix compatibility with stylelint 14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,10 +67,10 @@
     "prettier-plugin-organize-imports": "^2.3.4",
     "prettier-plugin-packagejson": "^2.2.18",
     "prettier-plugin-two-style-order": "^1.0.0",
-    "stylelint": "^13.0.0",
+    "stylelint": "^14.0.0",
     "stylelint-config-css-modules": "^2.2.0",
     "stylelint-config-prettier": "^8.0.1",
-    "stylelint-config-standard": "^20.0.0",
+    "stylelint-config-standard": "^26.0.0",
     "stylelint-declaration-block-no-ignored-properties": "^2.1.0",
     "typescript": "^4.5.4"
   },

--- a/src/stylelint.ts
+++ b/src/stylelint.ts
@@ -16,6 +16,8 @@ module.exports = {
     'unit-no-unknown': [true, { ignoreUnits: ['rpx'] }],
     // webcomponent
     'selector-type-no-unknown': null,
+    'selector-class-pattern': '^[a-z][a-zA-Z0-9_-]+$',  // skip errors from selector-class-pattern
+    'selector-id-pattern': '^[a-z][a-zA-Z0-9_-]+$',
     'value-keyword-case': ['lower', { ignoreProperties: ['composes'] }],
   },
   ignoreFiles: ['**/*.js', '**/*.jsx', '**/*.tsx', '**/*.ts'],


### PR DESCRIPTION
When stylelint upgrades to 14.x, projects using fabric's stylelint (like antd-pro) with throw errors:
`Unknown rule function-calc-no-invalid  function-calc-no-invalid`
'function-calc-no-invalid' is removed in stylelint 14.x, and in order to get rid of the error, stylelint-config-standard should be upgraded.