### PR TITLE
chore: fix warning React version not specified

### DIFF
--- a/src/eslint.ts
+++ b/src/eslint.ts
@@ -104,6 +104,9 @@ module.exports = {
     'import/extensions': ['.js', '.mjs', '.jsx', '.ts', '.tsx', '.d.ts'],
     'import/external-module-folders': ['node_modules', 'node_modules/@types'],
     polyfills: ['fetch', 'Promise', 'URL', 'object-assign'],
+    react: {
+      version: 'detect',
+    },
   },
   overrides: isTsProject
     ? [


### PR DESCRIPTION
Warning: React version not specified in eslint-plugin-react settings. See https://github.com/jsx-eslint/eslint-plugin-react#configuration

```
git clone https://github.com/ant-design/ant-design/
npm install
npm start
```

<img width="1271" alt="图片" src="https://user-images.githubusercontent.com/507615/175482045-2c64bbbb-3107-4636-8065-5969cbff0455.png">


原因是 antd 仓库里 @ant-design/bisheng-plugin 依赖了 https://github.com/umijs/sylvanas/ 依赖了 [fabric](https://github.com/umijs/fabric)。